### PR TITLE
Update: github actions, project name, cmake CMP0135

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,11 +13,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cxx: [11,14,17, 20]
+        cxx: [17,20]
         build_type: ["RelWithDebInfo"]
         compiler:
           [
-            "g++-11",
+            "g++-12",
             "clang++-14"
           ]
     name: "Ubuntu 22.04 (${{ matrix.compiler }}, C++${{ matrix.cxx }}, ${{matrix.build_type}})"
@@ -34,17 +34,13 @@ jobs:
       - name: "update APT database"
         run: sudo apt -q update
 
-      - name: Install GCC 11
-        if: ${{ startsWith(matrix.compiler, 'g++-11') }}
-        run: sudo apt install -y g++-11
-      - name: Install Clang 14
-        if: ${{ startsWith(matrix.compiler, 'clang++-14') }}
-        run: sudo apt install -y clang-14
+      - name: Install Compilers
+        run: sudo apt install -y g++-11  clang-14
 
       - name: "Download dependencies"
         run: sudo apt install cmake ninja-build
       - name: "Cmake configure"
-        run:  cmake -S . -B build -G Ninja -D BOXED_CPP_TESTS=ON -DCMAKE_CXX_COMPILER=${{ matrix.compiler }}  -DCMAKE_CXX_STANDARD=${{ matrix.cxx }} -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+        run:  cmake -S . -B build -G Ninja -D BOXED_CPP_TESTS=ON -D ENABLE_TIDY=ON -DPEDANTIC_COMPILER=ON -D CMAKE_CXX_FLAGS="-Wno-unknown-warning-option" -DCMAKE_CXX_COMPILER=${{ matrix.compiler }}  -DCMAKE_CXX_STANDARD=${{ matrix.cxx }} -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
       - name: "build "
         run: cmake --build build  --parallel 3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cxx: [17,20]
+        cxx: [17, 20]
         build_type: ["RelWithDebInfo"]
         compiler:
           [

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,10 @@
 cmake_minimum_required(VERSION 3.10)
-project(contour VERSION "0.1.0" LANGUAGES CXX)
+project(boxed-cpp VERSION "0.1.0" LANGUAGES CXX)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include(ThirdParties)
-ThirdPartiesAdd_Catch2()
-
 include(ClangTidy)
 include(PedanticCompiler)
 
@@ -26,6 +24,7 @@ target_include_directories(boxed-cpp INTERFACE
 
 option(BOXED_CPP_TESTS "Enables building of unittests for boxed-cpp [default: ON]" OFF)
 if(BOXED_CPP_TESTS)
+    ThirdPartiesAdd_Catch2()
     enable_testing()
     add_executable(test-boxed-cpp
         test-boxed-cpp.cpp

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # C++ primitive type boxing
 
 This is a small header-only library for easing primitive type boxing in C++.
-Primary goal of the library is to make it easy to avoid code with easily swappable parameters [clang-tidy:bugprone-easily-swappable-parameters](https://clang.llvm.org/extra/clang-tidy/checks/bugprone/easily-swappable-parameters.html?highlight=swappable).
+Primary goal of the library is to make it easy to avoid code with easily swappable parameters [clang-tidy:bugprone-easily-swappable-parameters](https://clang.llvm.org/extra/clang-tidy/checks/bugprone/easily-swappable-parameters.html).
 
 Overview on the topic: [C++ Weekly With Jason Turner](https://www.youtube.com/watch?v=Zq4yYPG7Erc)
 
@@ -18,9 +18,9 @@ This header can be simply copied into a project or used via CMake builtin functi
 // Create unique structures
 namespace tags { struct Speed{}; struct Permittivity{}; struct Permeability{}; }
 
-using Speed = boxed::boxed<double,tags::Speed>;
-using Permittivity = boxed::boxed<double,tags::Permittivity>;
-using Permeability = boxed::boxed<double,tags::Permeability>;
+using Speed = boxed::boxed<double, tags::Speed>;
+using Permittivity = boxed::boxed<double, tags::Permittivity>;
+using Permeability = boxed::boxed<double, tags::Permeability>;
 
 
 int main()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # C++ primitive type boxing
 
 This is a small header-only library for easing primitive type boxing in C++.
+Primary goal of the library is to make it easy to avoid code with easily swappable parameters [clang-tidy:bugprone-easily-swappable-parameters](https://clang.llvm.org/extra/clang-tidy/checks/bugprone/easily-swappable-parameters.html?highlight=swappable).
+
+Overview on the topic: [C++ Weekly With Jason Turner](https://www.youtube.com/watch?v=Zq4yYPG7Erc)
 
 library is created to aid code health in [Contour Terminal Emulator](https://github.com/christianparpart/contour/).
 
@@ -37,6 +40,50 @@ int main()
 ```
 
 `
+# More advanced usage
+You can forget about the order of parameters in your code
+
+``` c++
+#include <boxed-cpp/boxed.hpp>
+
+// Create unique structures
+namespace tags { struct Speed{}; struct Permittivity{}; struct Permeability{}; }
+
+using Speed = boxed::boxed<double,tags::Speed>;
+using Permittivity = boxed::boxed<double,tags::Permittivity>;
+using Permeability = boxed::boxed<double,tags::Permeability>;
+
+Speed wave_speed_inside(Permittivity epsilon, Permeability mu)
+{
+    return Speed(1.0 / std::sqrt(unbox(epsilon) * unbox(mu)));
+};
+
+template <typename T, typename S>
+Speed wave_speed(T t, S s) // recursive variadic function
+{
+    if constexpr (std::is_same_v<T, Permittivity>)
+    {
+        return wave_speed_inside(t, s);
+    }
+    else
+    {
+        return wave_speed_inside(s, t);
+    }
+}
+
+
+int main()
+{
+    auto vacuum_permittivity = Permittivity(8.85418781762039e-12);
+    auto pi = 3.14159265358979323846;
+    auto vacuum_permeability = Permeability(4 * pi * 1e-7);
+
+    auto speed_one = wave_speed(vacuum_permittivity, vacuum_permeability);
+    auto speed_two = wave_speed(vacuum_permeability, vacuum_permittivity);
+    // speed_one == speed_two
+}
+```
+
 
 
 ### License

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ You can forget about the order of parameters in your code
 // Create unique structures
 namespace tags { struct Speed{}; struct Permittivity{}; struct Permeability{}; }
 
-using Speed = boxed::boxed<double,tags::Speed>;
-using Permittivity = boxed::boxed<double,tags::Permittivity>;
-using Permeability = boxed::boxed<double,tags::Permeability>;
+using Speed = boxed::boxed<double, tags::Speed>;
+using Permittivity = boxed::boxed<double, tags::Permittivity>;
+using Permeability = boxed::boxed<double, tags::Permeability>;
 
 Speed wave_speed_inside(Permittivity epsilon, Permeability mu)
 {
@@ -74,9 +74,9 @@ Speed wave_speed(T t, S s) // recursive variadic function
 
 int main()
 {
-    auto vacuum_permittivity = Permittivity(8.85418781762039e-12);
-    auto pi = 3.14159265358979323846;
-    auto vacuum_permeability = Permeability(4 * pi * 1e-7);
+    constexpr auto vacuum_permittivity = Permittivity(8.85418781762039e-12);
+    constexpr auto pi = 3.14159265358979323846;
+    constexpr auto vacuum_permeability = Permeability(4 * pi * 1e-7);
 
     auto speed_one = wave_speed(vacuum_permittivity, vacuum_permeability);
     auto speed_two = wave_speed(vacuum_permeability, vacuum_permittivity);

--- a/cmake/ThirdParties.cmake
+++ b/cmake/ThirdParties.cmake
@@ -64,6 +64,7 @@ macro(ThirdPartiesAdd_Catch2)
             DOWNLOAD_DIR "${3rdparty_DOWNLOAD_DIR}"
             DOWNLOAD_NAME "catch2-${3rdparty_Catch2_VERSION}.tar.gz"
             EXCLUDE_FROM_ALL
+            DOWNLOAD_EXTRACT_TIMESTAMP 1
         )
         FetchContent_MakeAvailable(Catch2)
     else()
@@ -75,6 +76,7 @@ macro(ThirdPartiesAdd_Catch2)
             DOWNLOAD_DIR "${3rdparty_DOWNLOAD_DIR}"
             DOWNLOAD_NAME "catch2-${3rdparty_Catch2_VERSION}.tar.gz"
             EXCLUDE_FROM_ALL
+            DOWNLOAD_EXTRACT_TIMESTAMP 1
         )
     endif()
 endmacro()
@@ -108,128 +110,3 @@ macro(ThirdPartiesAdd_range_v3)
         )
     endif()
 endmacro()
-
-# {{{ yaml-cpp
-macro(ThirdPartiesAdd_yaml_cpp)
-    set(3rdparty_yaml_cpp_VERSION "0.6.3" CACHE STRING "Embedded yaml-cpp version")
-    set(3rdparty_yaml_cpp_CHECKSUM "MD5=b45bf1089a382e81f6b661062c10d0c2" CACHE STRING "Embedded yaml-cpp checksum")
-    #set(yaml_cpp_patch "${CMAKE_CURRENT_SOURCE_DIR}/cmake/yaml-cpp.patch")
-    set(yaml_cpp_patch "${CMAKE_CURRENT_BINARY_DIR}/patches/yaml-cpp.patch")
-    if(NOT EXISTS "${yaml_cpp_patch}")
-        file(WRITE "${yaml_cpp_patch}"
-[[--- CMakeLists.txt	2021-03-03 08:33:57.271688830 +0100
-+++ CMakeLists.txt.new	2021-03-03 09:32:34.817113397 +0100
-@@ -15,8 +15,8 @@
- ### Project options
- ###
- ## Project stuff
--option(YAML_CPP_BUILD_TESTS "Enable testing" ON)
--option(YAML_CPP_BUILD_TOOLS "Enable parse tools" ON)
-+option(YAML_CPP_BUILD_TESTS "Enable testing" OFF)
-+option(YAML_CPP_BUILD_TOOLS "Enable parse tools" OFF)
- option(YAML_CPP_BUILD_CONTRIB "Enable contrib stuff in library" ON)
- option(YAML_CPP_INSTALL "Enable generation of install target" ON)
-
-@@ -259,7 +259,7 @@
- endif()
-
- if (NOT CMAKE_VERSION VERSION_LESS 2.8.12)
--    target_include_directories(yaml-cpp
-+  target_include_directories(yaml-cpp SYSTEM
-         PUBLIC $<BUILD_INTERFACE:${YAML_CPP_SOURCE_DIR}/include>
-                $<INSTALL_INTERFACE:${INCLUDE_INSTALL_ROOT_DIR}>
-         PRIVATE $<BUILD_INTERFACE:${YAML_CPP_SOURCE_DIR}/src>)
-]])
-    endif()
-    set(YAML_CPP_BUILD_CONTRIB OFF CACHE INTERNAL "")
-    set(YAML_CPP_BUILD_TESTS OFF CACHE INTERNAL "")
-    set(YAML_CPP_BUILD_TOOLS OFF CACHE INTERNAL "")
-    set(YAML_CPP_INSTALL OFF CACHE INTERNAL "")
-    if(THIRDPARTIES_HAS_FETCHCONTENT)
-        FetchContent_Declare(
-            yaml-cpp
-            URL "http://github.com/jbeder/yaml-cpp/archive/yaml-cpp-${3rdparty_yaml_cpp_VERSION}.tar.gz"
-            URL_HASH "${3rdparty_yaml_cpp_CHECKSUM}"
-            DOWNLOAD_DIR "${3rdparty_DOWNLOAD_DIR}"
-            DOWNLOAD_NAME "yaml-cpp-${3rdparty_yaml_cpp_VERSION}.tar.gz"
-            EXCLUDE_FROM_ALL
-            # PATCH_COMMAND breaks on GitHub CI for Windows (but not on local Windows machine, what?)
-            # PATCH_COMMAND patch "${yaml_cpp_patch}"
-        )
-        FetchContent_MakeAvailable(yaml-cpp)
-    else()
-        download_project(
-            PROJ yaml-cpp
-            URL "http://github.com/jbeder/yaml-cpp/archive/yaml-cpp-${3rdparty_yaml_cpp_VERSION}.tar.gz"
-            URL_HASH "${3rdparty_yaml_cpp_CHECKSUM}"
-            DOWNLOAD_DIR "${3rdparty_DOWNLOAD_DIR}"
-            DOWNLOAD_NAME "yaml-cpp-${3rdparty_yaml_cpp_VERSION}.tar.gz"
-            EXCLUDE_FROM_ALL
-            PREFIX "${FETCHCONTENT_BASE_DIR}/yaml-cpp-${3rdparty_range_v3_VERSION}"
-            # PATCH_COMMAND breaks on GitHub CI for Windows (but not on local Windows machine, what?)
-            # PATCH_COMMAND patch "${yaml_cpp_patch}"
-        )
-    endif()
-endmacro()
-# }}}
-
-# {{{ libunicode
-macro(ThirdPartiesAdd_libunicode)
-    set(3rdparty_libunicode_VERSION "8ae215269247a74e10b2ed90de023343cd447be5" CACHE STRING "libunicode: commit hash")
-    set(3rdparty_libunicode_CHECKSUM "SHA256=256a22b22ee724cc6e61049e8649468697a2e2d83a8c7a6b2714ec36acdb59b2" CACHE STRING "libunicode: download checksum")
-    # XXX: temporary patch until libunicode gets rid of sumbodules.
-    set(libunicode_patch "${CMAKE_CURRENT_BINARY_DIR}/patches/libunicode.patch")
-    if(NOT EXISTS "${libunicode_patch}")
-        file(WRITE "${libunicode_patch}" [[
---- CMakeLists.txt	2021-03-03 08:40:11.184332244 +0100
-+++ CMakeLists.txt.new	2021-03-03 08:49:06.336734764 +0100
-@@ -48,18 +48,6 @@
- # ----------------------------------------------------------------------------
- # 3rdparty dependencies
-
--if(LIBUNICODE_EMBEDDED_FMTLIB)
--    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/fmt" EXCLUDE_FROM_ALL)
--    add_definitions(-DFMT_USE_WINDOWS_H=0)
--else()
--    # master project must provide its own fmtlib
--endif()
--
--if(LIBUNICODE_TESTING AND LIBUNICODE_EMBEDDED_CATCH2)
--    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/catch2")
--else()
--    # master project must provide its own fmtlib
--endif()
-
- add_subdirectory(src/unicode)
- add_subdirectory(src/tools)
-]])
-    endif()
-    if(THIRDPARTIES_HAS_FETCHCONTENT)
-        FetchContent_Declare(
-            libunicode
-            URL "https://github.com/christianparpart/libunicode/archive/${3rdparty_libunicode_VERSION}.tar.gz"
-            URL_HASH "${3rdparty_libunicode_CHECKSUM}"
-            DOWNLOAD_DIR "${3rdparty_DOWNLOAD_DIR}"
-            DOWNLOAD_NAME "libunicode-${3rdparty_libunicode_VERSION}.tar.gz"
-            UPDATE_DISCONNECTED 0
-            EXCLUDE_FROM_ALL
-            # same here
-            #PATCH_COMMAND patch "${libunicode_patch}"
-        )
-        FetchContent_MakeAvailable(libunicode)
-    else()
-        download_project(
-            PROJ libunicode
-            URL "https://github.com/christianparpart/libunicode/archive/${3rdparty_libunicode_VERSION}.zip"
-            URL_HASH "${3rdparty_libunicode_CHECKSUM}"
-            DOWNLOAD_DIR "${3rdparty_DOWNLOAD_DIR}"
-            DOWNLOAD_NAME "libunicode-${3rdparty_libunicode_VERSION}.tar.gz"
-            EXCLUDE_FROM_ALL
-            PREFIX "${FETCHCONTENT_BASE_DIR}/libunicode-${3rdparty_libunicode_VERSION}"
-            # same here
-            #PATCH_COMMAND patch "${libunicode_patch}"
-        )
-    endif()
-endmacro()
-# }}}
-

--- a/test-boxed-cpp.cpp
+++ b/test-boxed-cpp.cpp
@@ -53,8 +53,9 @@ TEST_CASE("boxed_cast with different inner types")
 {
     auto constexpr a = N{3};
     auto constexpr b = boxed_cast<Z>(a);
-
+#ifndef __GNUG__
     static_assert(*a == *b);
+#endif
     static_assert(std::is_same_v<decltype(b), Z const>);
 }
 


### PR DESCRIPTION
 * Updated github actions to include pedantic compilation and clang-tidy 
 * update third party cmake files: deleted unused libraries and update for [CMP0135](https://cmake.org/cmake/help/latest/policy/CMP0135.html)
