### PR TITLE
Add SFINAE for plain unbox instead of template

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(boxed_cpp_HEADERS
 )
 add_library(boxed-cpp INTERFACE)
 
-target_compile_features(boxed-cpp INTERFACE cxx_std_17)
+target_compile_features(boxed-cpp INTERFACE cxx_std_20)
 target_include_directories(boxed-cpp INTERFACE
     $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/include>

--- a/include/boxed-cpp/boxed.hpp
+++ b/include/boxed-cpp/boxed.hpp
@@ -164,11 +164,17 @@ constexpr auto unbox(boxed::boxed<From, FromTag> const& from) noexcept
     return static_cast<To>(from.value);
 }
 
-// Casting a boxed type out of the box.
-template <typename From, typename FromTag>
-constexpr auto unbox(boxed::boxed<From, FromTag> const& from) noexcept
+template <typename T>
+concept con_boxed = requires(T t)
 {
-    return unbox<From,From,FromTag>(from);
+    typename T::inner_type;
+};
+
+// Casting a boxed type out of the box.
+template <con_boxed T>
+constexpr auto unbox(T from) noexcept
+{
+    return unbox<typename T::inner_type>(from);
 }
 
 namespace std

--- a/test-boxed-cpp.cpp
+++ b/test-boxed-cpp.cpp
@@ -110,3 +110,11 @@ TEST_CASE("cast inside rvalue")
     double distance_d = speed_of_light * 2.0;
     REQUIRE(distance_d - 2.0 * 299792458.0 < std::numeric_limits<double>::epsilon());
 }
+
+TEST_CASE("all options for unbox")
+{
+    auto speed_of_light = Speed(299792458.0);
+    REQUIRE(unbox<double>(speed_of_light));
+    REQUIRE(unbox<float>(speed_of_light));
+    REQUIRE(unbox(speed_of_light));
+}


### PR DESCRIPTION
PR changes  `unbox` function in such way that we can call unbox with internal type without getting ambiguous template instantiation. 
Previously,  with `using myType = boxed<double,TAG>` usage of unbox function with implicit template argument (as `unbox<double>(boxed_val)`)  of inner_type was forbidden due to ambiguous templates. 
This PR update unbox function handling to get rid of this issue.