### PR TITLE
CMake improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,27 +4,60 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+include(GNUInstallDirs)
 include(ThirdParties)
 include(ClangTidy)
 include(PedanticCompiler)
 
 set(boxed_cpp_HEADERS
-    include/boxed-cpp/boxed.hpp
+    ${PROJECT_SOURCE_DIR}/include/boxed-cpp/boxed.hpp
 )
 add_library(boxed-cpp INTERFACE)
+add_library(boxed-cpp::boxed-cpp ALIAS boxed-cpp)
 
 target_compile_features(boxed-cpp INTERFACE cxx_std_20)
 target_include_directories(boxed-cpp INTERFACE
     $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+# Generate the version, config and target files
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/boxed-cpp-config-version.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+configure_package_config_file(boxed-cpp-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/boxed-cpp-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/boxed-cpp
+)
+
+install(FILES ${boxed_cpp_HEADERS}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/boxed-cpp
+)
+install(TARGETS boxed-cpp
+    EXPORT boxed-cpp-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/boxed-cpp-config.cmake
+            ${CMAKE_CURRENT_BINARY_DIR}/boxed-cpp-config-version.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/boxed-cpp
+)
+install(EXPORT boxed-cpp-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/boxed-cpp
+    NAMESPACE boxed-cpp::
 )
 
 # ---------------------------------------------------------------------------
 # unit tests
 
-option(BOXED_CPP_TESTS "Enables building of unittests for boxed-cpp [default: ON]" OFF)
+option(BOXED_CPP_TESTS "Enables building of unittests for boxed-cpp [default: OFF]" OFF)
 if(BOXED_CPP_TESTS)
-    ThirdPartiesAdd_Catch2()
+    find_package(Catch2)
+    if (NOT Catch2_FOUND)
+        ThirdPartiesAdd_Catch2()
+    endif()
     enable_testing()
     add_executable(test-boxed-cpp
         test-boxed-cpp.cpp

--- a/boxed-cpp-config.cmake.in
+++ b/boxed-cpp-config.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+# prevent repeatedly including the targets
+if(NOT TARGET boxed-cpp::boxed-cpp)
+    include(${CMAKE_CURRENT_LIST_DIR}/boxed-cpp-targets.cmake)
+endif()
+
+message(STATUS "Found @PROJECT_NAME@, version: ${@PROJECT_NAME@_VERSION}")


### PR DESCRIPTION
close #8 

```
write_basic_package_version_file(<filename>
  [VERSION <major.minor.patch>]
  COMPATIBILITY <AnyNewerVersion|SameMajorVersion|SameMinorVersion|ExactVersion>
  [ARCH_INDEPENDENT] )
```

There are some extra questions.
1. which `COMPATIBILITY` mode will be appropriate to use? `AnyNewerVersion`, `SameMajorVersion`, `SameMinorVersion` and `ExactVersion` .
2. `ARCH_INDEPENDENT` in `write_basic_package_version_file` can be used when CMake version >= 3.14 since boxed-cpp is a header-only package and architecture-independent.

```cmake
# https://github.com/xtensor-stack/xtl/blob/908958eb8edebc4fdb0c5cd9b86912bca3eca5c9/CMakeLists.txt#L129-L144
if(CMAKE_VERSION VERSION_LESS 3.14)
    set(BOXED_CPP_CMAKE_SIZEOF_VOID_P ${CMAKE_SIZEOF_VOID_P})
    unset(CMAKE_SIZEOF_VOID_P)
    write_basic_package_version_file(
        ${CMAKE_CURRENT_BINARY_DIR}/boxed-cpp-config-version.cmake
        VERSION ${PROJECT_VERSION}
        COMPATIBILITY SameMajorVersion
    )
    set(CMAKE_SIZEOF_VOID_P ${BOXED_CPP_CMAKE_SIZEOF_VOID_P})
else()
    write_basic_package_version_file(
        ${CMAKE_CURRENT_BINARY_DIR}/boxed-cpp-config-version.cmake
        VERSION ${PROJECT_VERSION}
        COMPATIBILITY SameMajorVersion
        ARCH_INDEPENDENT
    )
endif()
```
Or just update the CMake minimum version restriction to version 3.14.

Ref:
- https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html#command:write_basic_package_version_file
- https://github.com/doctest/doctest/pull/225
