### PR TITLE
Introduced a way to generate tags automatically

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,15 @@ jobs:
     name: "Check C++ style"
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
-    - name: Run clang-format style check for C/C++/Protobuf programs.
-      uses: jidicula/clang-format-action@v4.11.0
-      with:
-        clang-format-version: '16'
-        check-path: '.'
-        #exclude-regex: 'sse2neon.h'
+      - uses: actions/checkout@v3
+      - name: Install clang
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 17
+          sudo apt-get install clang-format-17
+      - name: "Clang-format"
+        run: clang-format-17 --Werror --dry-run test-boxed-cpp.cpp include/boxed-cpp/boxed.hpp
 
   editorconfig:
     name: "Check editorconfig"
@@ -33,51 +35,49 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-22.04, ubuntu-20.04]
         cxx: [20]
         build_type: ["RelWithDebInfo"]
-        compiler:
+        llvm_version:
           [
-            "g++-11",
-            "clang++-15"
+            "17",
+            "18"
           ]
-    name: "Ubuntu 22.04 (${{ matrix.compiler }}, C++${{ matrix.cxx }}, ${{matrix.build_type}})"
-    runs-on: ubuntu-22.04
+    name: " ${{ matrix.os }} (clang-${{ matrix.llvm_version }}, C++${{ matrix.cxx }}, ${{matrix.build_type}})"
+    runs-on: ${{ matrix.os }}
     outputs:
       id: "${{ matrix.compiler }} (C++${{ matrix.cxx }}, ${{ matrix.build_type }})"
     steps:
       - uses: actions/checkout@v3
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          key: "ccache-ubuntu2204-${{ matrix.compiler }}-${{ matrix.cxx }}-${{ matrix.build_type }}"
-          max-size: 256M
+      # - name: ccache
+      #   uses: hendrikmuhs/ccache-action@v1.2
+      #   with:
+      #     key: "ccache-ubuntu2204-${{ matrix.compiler }}-${{ matrix.cxx }}-${{ matrix.build_type }}"
+      #     max-size: 256M
       - name: "update APT database"
         run: sudo apt -q update
 
-      - name: Set up Clang
-        uses: egor-tensin/setup-clang@v1
-        with:
-          version: 15
 
+      - name: Install clang
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh ${{ matrix.llvm_version }}
+        # can not use clang-tidy until https://github.com/actions/runner-images/issues/8659 get fixed
       - name: "Download dependencies"
         run: sudo apt install cmake ninja-build # catch2
-      # workaround for broken clang on ubuntu runner until https://github.com/actions/runner-images/issues/8659 get fixed
-      #- uses: mjp41/workaround8649@7929373c0fe5caf844d8115adccef39e3b5362e7
-      - name: Install Compilers
-        run: sudo apt install -y g++-12
       - name: "Cmake configure"
         run: |
           cmake -S . -B build -G Ninja \
-              -DBOXED_CPP_TESTS=OFF \
-              -DENABLE_TIDY=ON \
-              -DPEDANTIC_COMPILER=ON \
+              -DBOXED_TESTING=ON \
+              -DENABLE_TIDY=OFF \
+              -DPEDANTIC_COMPILER=OFF \
               -DCMAKE_CXX_FLAGS="-Wno-unknown-warning-option" \
-              -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} \
               -DCMAKE_CXX_STANDARD=${{ matrix.cxx }} \
+              -DCMAKE_CXX_COMPILER=clang++-${{ matrix.llvm_version }} \
               -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
       - name: "build"
         run: cmake --build build  --parallel 3
 
       - name: "run test"
-        if: ${{ false }} # disabled, because of Github runner image bug in compiler-vs-stdlib
         run: ./build/test-boxed-cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,8 +52,8 @@ install(EXPORT boxed-cpp-targets
 # ---------------------------------------------------------------------------
 # unit tests
 
-option(BOXED_CPP_TESTS "Enables building of unittests for boxed-cpp [default: OFF]" OFF)
-if(BOXED_CPP_TESTS)
+option(BOXED_TESTING "Enables building of unittests for boxed-cpp [default: OFF]" OFF)
+if(BOXED_TESTING)
     find_package(Catch2 3.4.0 QUIET)
     if(NOT Catch2_FOUND)
         ThirdPartiesAdd_Catch2()
@@ -62,7 +62,8 @@ if(BOXED_CPP_TESTS)
     add_executable(test-boxed-cpp
         test-boxed-cpp.cpp
     )
+    target_compile_features(test-boxed-cpp INTERFACE cxx_std_20)
     target_link_libraries(test-boxed-cpp boxed-cpp Catch2::Catch2WithMain)
     add_test(test-boxed-cpp ./test-boxed-cpp)
 endif()
-message(STATUS "[boxed-cpp] Compile unit tests: ${BOXED_CPP_TESTS}")
+message(STATUS "[boxed-cpp] Compile unit tests: ${BOXED_TESTING}")

--- a/README.md
+++ b/README.md
@@ -17,12 +17,10 @@ Example of creation boxed structures and usage
 #include <boxed-cpp/boxed.hpp>
 
 // Create unique structures
-namespace tags { struct Speed{}; struct Permittivity{}; struct Permeability{}; }
 
-using Speed = boxed::boxed<double, tags::Speed>;
-using Permittivity = boxed::boxed<double, tags::Permittivity>;
-using Permeability = boxed::boxed<double, tags::Permeability>;
-
+using Speed = boxed::boxed<double>;
+using Permittivity = boxed::boxed<double>;
+using Permeability = boxed::boxed<double>;
 
 int main()
 {
@@ -36,6 +34,9 @@ int main()
 
     auto speed = wave_speed(vacuum_permittivity, vacuum_permeability);
     // speed == Speed(299792458.0);
+
+    // Wrong order of parameters will result in compilation error
+    // wave_speed(vacuum_permeability, vacuum_permittivity);
 }
 
 ```
@@ -62,13 +63,13 @@ double value_d = speed_of_light * 2.0;
 ```
 
 
-# More advanced usage
-You can forget about the order of parameters in your code. Complete code see: [godbolt](https://godbolt.org/z/K4r9d9far)
+# More examples of usage
+You can crate functions that will automatically adjust order of parameters. Complete code see: [godbolt](https://godbolt.org/z/aqobbcGe6)
 
 ``` c++
-using rho_type = boxed::boxed<double,Tag::Rho>;
-using theta_type = boxed::boxed<double,Tag::Theta>;
-using phi_type = boxed::boxed<double,Tag::Phi>;
+using rho_type = boxed::boxed<double>;
+using theta_type = boxed::boxed<double>;
+using phi_type = boxed::boxed<double>;
 
 template <typename... F>
 struct overload: F...{ using F::operator()...;};
@@ -89,7 +90,6 @@ struct Wrap
     }
 };
 
-
 auto x_coord = Wrap([](rho_type rho){ return unbox(rho); },
                     [](theta_type theta){ return sin(unbox(theta)); },
                     [](phi_type phi){ return cos(unbox(phi)); }
@@ -101,9 +101,9 @@ int main()
     theta_type theta{3.14 / 3.0};
     phi_type phi{3.14/2.0};
 
-    assert(x_coord(rho,theta,phi) == x_coord(theta,rho,phi));
-    assert(x_coord(rho,theta,phi) == x_coord(phi,rho,theta));
-    assert(x_coord(rho,theta,phi) == x_coord(phi,rho,theta));
+    std::cout << x_coord(rho,theta,phi) << std::endl; // 0.000689428
+    std::cout << x_coord(phi,theta,rho) << std::endl; // 0.000689428
+    std::cout << x_coord(rho,phi,theta) << std::endl; // 0.000689428
 }
 ```
 


### PR DESCRIPTION
Introduced a way to declare boxed types without specifying unique tag, added tests and updated README

Also, some context on how this is possible 
https://stackoverflow.com/questions/22232164/why-are-lambda-expressions-not-allowed-in-an-unevaluated-operands-but-allowed-in

https://en.cppreference.com/w/cpp/language/lambda#Lambdas_in_unevaluated_contexts

Compilers support:
https://en.cppreference.com/w/cpp/compiler_support#C.2B.2B20_features 
See `Lambdas in unevaluated contexts` entry