### PR TITLE
do not put fmt::formatter into fmt namespace

### DIFF
--- a/include/boxed-cpp/boxed.hpp
+++ b/include/boxed-cpp/boxed.hpp
@@ -212,9 +212,6 @@ struct hash<boxed::detail::boxed<T, U>>
 #include <fmt/format.h>
 // clang-format on
 
-namespace fmt
-{
-
 template <typename Type, typename Tag>
 struct fmt::formatter<boxed::detail::boxed<Type, Tag>>
 {
@@ -226,6 +223,5 @@ struct fmt::formatter<boxed::detail::boxed<Type, Tag>>
     }
 };
 
-} // namespace fmt
 #endif
 // }}}

--- a/include/boxed-cpp/boxed.hpp
+++ b/include/boxed-cpp/boxed.hpp
@@ -217,7 +217,7 @@ struct fmt::formatter<boxed::detail::boxed<Type, Tag>>
 {
     constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
 
-    auto format(boxed::detail::boxed<Type, Tag> const& val, fmt::format_context& ctx)
+    auto format(boxed::detail::boxed<Type, Tag> const& val, fmt::format_context& ctx) const
     {
         return fmt::format_to(ctx.out(), "{}", val.value);
     }


### PR DESCRIPTION
as fmt::formatter already has the namespace qualifier. otherwise, the build would fail when building with fmt 11, like:

```
/usr/include/boxed-cpp/boxed.hpp:218:8: error: extra qualification not allowed [-fpermissive]
  218 | struct fmt::formatter<boxed::detail::boxed<Type, Tag>>
      |        ^~~
In file included from /usr/include/fmt/format.h:41,
                 from /usr/include/boxed-cpp/boxed.hpp:211:
/usr/include/fmt/base.h: In instantiation of â€˜static void fmt::v11::detail::value<Context>::format_custom_arg(void*, typename Context::parse_context_type&, Context&) [with T = boxed::detail::boxed<unsigned int, vtpty::detail::tags::Width>; Formatter = fmt::v11::formatter<boxed::detail::boxed<unsigned int, vtpty::detail::tags::Width>, char, void>; Context = fmt::v11::context; typename Context::parse_context_type = fmt::v11::basic_format_parse_context<char>]â€™:
/usr/include/fmt/base.h:1373:19:   required from â€˜constexpr fmt::v11::detail::value<Context>::value(T&) [with T = boxed::detail::boxed<unsigned int, vtpty::detail::tags::Width>; Context = fmt::v11::context]â€™
 1373 |     custom.format = format_custom_arg<
      |     ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
 1374 |         value_type, typename Context::template formatter_type<value_type>>;
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/base.h:1631:41:   required from â€˜constexpr fmt::v11::detail::format_arg_store<Context, NUM_ARGS, 0, DESC> fmt::v11::make_format_args(T& ...) [with Context = context; T = {boxed::detail::boxed<unsigned int, vtpty::detail::tags::Width>, boxed::detail::boxed<unsigned int, vtpty::detail::tags::Height>}; long unsigned int NUM_ARGS = 2; long unsigned int NUM_NAMED_ARGS = 0; long long unsigned int DESC = 255; typename std::enable_if<(NUM_NAMED_ARGS == 0), int>::type <anonymous> = 0]â€™
 1631 |   return {arg_mapper<Context>().map(val)};
      |                                         ^
```